### PR TITLE
ripristinata la mappa di sintesi anche se i CDU non la contemplano

### DIFF
--- a/frontend/assets/cardTemplateBdnDistribuzioneFauna.jsxt
+++ b/frontend/assets/cardTemplateBdnDistribuzioneFauna.jsxt
@@ -93,6 +93,41 @@
                     features={model.getValue("/wfs:FeatureCollection/wfs:member/decsiraogc_biodiversita_bdn_griglia_distr_fauna:BdnDistribuzioneFauna/decsiraogc_biodiversita_bdn_griglia_distr_fauna:bdnSpecieGrigliaFauna")}/>
                     </Section>
 
+                <Section header='MAPPA SINTESI - Banche Dati Naturalistiche: griglia di distribuzione fauna su sfondo BDTRE (Banca Dati Territoriale di Riferimento Enti)' eventKey='13' expanded={true}>
+                    <MappaScheda
+                            center={
+                                    model.getValue({
+                                        type: TemplateUtils.GEOMETRY_TYPE,
+                                        xpath: "/wfs:FeatureCollection/wfs:member/decsiraogc_biodiversita_bdn_griglia_distr_fauna:BdnDistribuzioneFauna/decsiraogc_biodiversita_bdn_griglia_distr_fauna:geometria/gml:Polygon/gml:exterior/gml:LinearRing/gml:posList/text()"
+                                    })
+                            }
+                            layers={[
+                                    {
+                                        "type": "wms",
+                                        "url": "http://geomap.reteunitaria.piemonte.it/ws/taims/rp-01/taimsbasewms/wms_sfondo_cart_rif",
+                                        "name": "SfondoCartRif",
+                                        "title": "Sfondo Cartografico",
+                                        "group": "background",
+                                        "visibility": true,
+                                        "format": "image/png",
+                                        "tiled": true,
+                                        "tileSize": 512
+                                    },
+                                    {
+                                        "type": "wms",
+                                        "url": "{geoserverUrl}/wms",
+                                        "visibility": true,
+                                        "title": "Anteprima Griglia di distribuzione Fauna",
+                                        "name": "decsiraogc_biodiversita_bdn_griglia_distr_fauna:BdnDistribuzioneFauna",
+                                        "group": "Overlays",
+                                        "format": "image/png"
+                                    }
+                            ]}
+                            authParam={model.authParam}
+                            withMap={model.withMap}/>
+
+                    </Section>
+
 	
     </Panel>
 </Panel>

--- a/frontend/assets/cardTemplateBdnDistribuzioneFlora.jsxt
+++ b/frontend/assets/cardTemplateBdnDistribuzioneFlora.jsxt
@@ -92,6 +92,41 @@
                         ]
                     }
                     features={model.getValue("/wfs:FeatureCollection/wfs:member/decsiraogc_biodiversita_bdn_griglia_distr_flora:BdnDistribuzioneFlora/decsiraogc_biodiversita_bdn_griglia_distr_flora:bdnSpecieGrigliaFlora")}/>
+            </Section>
+
+             <Section header='MAPPA SINTESI - Banche Dati Naturalistiche: griglia di distribuzione flora su sfondo BDTRE (Banca Dati Territoriale di Riferimento Enti)' eventKey='13' expanded={true}>
+                    <MappaScheda
+                            center={
+                                    model.getValue({
+                                        type: TemplateUtils.GEOMETRY_TYPE,
+                                        xpath: "/wfs:FeatureCollection/wfs:member/decsiraogc_biodiversita_bdn_griglia_distr_flora:BdnDistribuzioneFlora/decsiraogc_biodiversita_bdn_griglia_distr_flora:geometria/gml:Polygon/gml:exterior/gml:LinearRing/gml:posList/text()"
+                                    })
+                            }
+                            layers={[
+                                    {
+                                        "type": "wms",
+                                        "url": "http://geomap.reteunitaria.piemonte.it/ws/taims/rp-01/taimsbasewms/wms_sfondo_cart_rif",
+                                        "name": "SfondoCartRif",
+                                        "title": "Sfondo Cartografico",
+                                        "group": "background",
+                                        "visibility": true,
+                                        "format": "image/png",
+                                        "tiled": true,
+                                        "tileSize": 512
+                                    },
+                                    {
+                                        "type": "wms",
+                                        "url": "{geoserverUrl}/wms",
+                                        "visibility": true,
+                                        "title": "Anteprima Griglia di distribuzione Flora",
+                                        "name": "decsiraogc_biodiversita_bdn_griglia_distr_flora:BdnDistribuzioneFlora",
+                                        "group": "Overlays",
+                                        "format": "image/png"
+                                    }
+                            ]}
+                            authParam={model.authParam}
+                            withMap={model.withMap}/>
+
                     </Section>
 	
     </Panel>

--- a/frontend/assets/cardTemplateBdnOsservazioniFauna.jsxt
+++ b/frontend/assets/cardTemplateBdnOsservazioniFauna.jsxt
@@ -13,6 +13,42 @@
 				model.getValue("/wfs:FeatureCollection/wfs:member/decsiraogc_biodiversita_bdn_osservazioni_fauna:BdnOsservazioniFauna/decsiraogc_biodiversita_bdn_osservazioni_fauna:codiceRilievo/text()")
 			}/>    
 		</Section>
+
+
+    <Section header='MAPPA SINTESI - FAUNA BANCA DATI NATURALISTICHE su sfondo BDTRE (Banca Dati Territoriale di Riferimento Enti)' eventKey='13' expanded={true}>
+	      <MappaScheda
+	              center={
+	                      model.getValue({
+	                          type: TemplateUtils.GEOMETRY_TYPE,
+	                          xpath: "/wfs:FeatureCollection/wfs:member/decsiraogc_biodiversita_bdn_osservazioni_fauna:BdnOsservazioniFauna/decsiraogc_biodiversita_bdn_osservazioni_fauna:geometria/gml:Point/gml:pos/text()"
+	                      })
+	              }
+	              layers={[
+	                      {
+							  "type": "wms",
+							  "url": "http://geomap.reteunitaria.piemonte.it/ws/taims/rp-01/taimsbasewms/wms_sfondo_cart_rif",
+							  "name": "SfondoCartRif",
+							  "title": "Sfondo Cartografico",
+							  "group": "background",
+							  "visibility": true,
+							  "format": "image/png",
+							  "tiled": true,
+							  "tileSize": 512
+                          },
+	                      {
+	                          "type": "wms",
+	                          "url": "{geoserverUrl}/wms",
+	                          "visibility": true,
+	                          "title": "Anteprima Osservazioni Fauna",
+	                          "name": "decsiraogc_biodiversita_bdn_osservazioni_fauna:BdnOsservazioniFauna",
+	                          "group": "Overlays",
+	                          "format": "image/png"
+	                      }
+	              ]}
+	              authParam={model.authParam}
+	              withMap={model.withMap}/>
+
+        </Section>
 	
     </Panel>
 

--- a/frontend/assets/cardTemplateBdnOsservazioniFlora.jsxt
+++ b/frontend/assets/cardTemplateBdnOsservazioniFlora.jsxt
@@ -16,6 +16,41 @@
         }/>
     
     </Section>
+
+    <Section header='MAPPA SINTESI - FLORA BANCA DATI NATURALISTICHE su sfondo BDTRE (Banca Dati Territoriale di Riferimento Enti)' eventKey='13' expanded={true}>
+	      <MappaScheda
+	              center={
+	                      model.getValue({
+	                          type: TemplateUtils.GEOMETRY_TYPE,
+	                          xpath: "/wfs:FeatureCollection/wfs:member/decsiraogc_biodiversita_bdn_osservazioni_flora:BdnOsservazioniFlora/decsiraogc_biodiversita_bdn_osservazioni_flora:geometria/gml:Point/gml:pos/text()"
+	                      })
+	              }
+	              layers={[
+	                      {
+							  "type": "wms",
+							  "url": "http://geomap.reteunitaria.piemonte.it/ws/taims/rp-01/taimsbasewms/wms_sfondo_cart_rif",
+							  "name": "SfondoCartRif",
+							  "title": "Sfondo Cartografico",
+							  "group": "background",
+							  "visibility": true,
+							  "format": "image/png",
+							  "tiled": true,
+							  "tileSize": 512
+                          },
+	                      {
+	                          "type": "wms",
+	                          "url": "{geoserverUrl}/wms",
+	                          "visibility": true,
+	                          "title": "Anteprima Osservazioni Flora",
+	                          "name": "decsiraogc_biodiversita_bdn_osservazioni_flora:BdnOsservazioniFlora",
+	                          "group": "Overlays",
+	                          "format": "image/png"
+	                      }
+	              ]}
+	              authParam={model.authParam}
+	              withMap={model.withMap}/>
+
+        </Section>
 	
 	
 	


### PR DESCRIPTION
Non sapendo che se non c'è la mappa di sintesi sul dettaglio non funziona il metodo di stampa della scheda.
